### PR TITLE
Removed "key vault name" input variable from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ module "backend" {
   resource_group_name       = local.name
   storage_account_name      = local.name
   storage_container_name    = "tfstate" # unique storage container name
-  azure_key_vault_name      = local.name
   resource_group_location   = local.region
   environment               = local.environment
 }


### PR DESCRIPTION
### What?

In this PR we have removed removed "key vault name" input variable from README.md

### Why?

Removed resource "key vault" from the module when got to know about how Azure blob storage handles the terraform tfstate locking.